### PR TITLE
add a github action to format build and lint the project on pull requests

### DIFF
--- a/.github/build-and-test.yaml
+++ b/.github/build-and-test.yaml
@@ -1,0 +1,72 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+
+name: Format, Build, and Lint
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: "npm"
+      - name: Fetch Prettier Cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ./node_modules/.cache/prettier/.prettier-cache
+          key: prettier-cache-${{ hashFiles('.prettierrc.ts') }} # cache bust on the config file to drop caches if plugins are added
+      - name: Prettier Fix Format
+        id: format
+        run:
+          | # format the codebase with Prettier and take note of the files that were changed
+          {
+            echo 'FORMATTED_FILES<<EOF'
+            npx prettier --write . --cache --list-different
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+      - name: Save Prettier Cache
+        uses: actions/cache/save@v4
+        with:
+          path: ./node_modules/.cache/prettier/.prettier-cache
+          key: prettier-cache-${{ hashFiles('.prettierrc.ts') }}
+      - name: Commit and Push Prettier Changes
+        run: >
+          if [ -z "${{ steps.format.outputs.FORMATTED_FILES }}" ]; then
+            echo "No files were formatted by Prettier."
+            exit 0
+          fi
+          ; git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          ; git config user.name "github-actions[bot]"
+          ; echo "${{ steps.format.outputs.FORMATTED_FILES }}"
+          | git commit -m "chore: apply Prettier formatting" 
+          --author "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+          --pathspec-from-file -
+          && git push
+
+  build-and-lint:
+    needs: format
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: "npm"
+      - run: npm ci
+      - run: npm run build # typescript compile, bundling, and static file generation
+      - run: npm run lint


### PR DESCRIPTION
### TL;DR

Added GitHub Actions workflow for automated code formatting, building, and linting.

### What changed?

Created a new GitHub Actions workflow file (`.github/build-and-test.yaml`) that:
- Runs on pushes to main branch and all pull requests
- Includes two jobs:
  1. `format`: Automatically formats code with Prettier and commits any changes
  2. `build-and-lint`: Builds the project and runs linting checks

The format job uses caching to improve performance and automatically commits any formatting changes back to the branch.

### Why make this change?

This workflow ensures consistent code style across the project by automatically applying Prettier formatting. It also validates that the code builds correctly and passes linting checks, helping to catch issues early in the development process and maintain code quality.