### PR TITLE
Add a little nugget of typesafety on Next `<Link>` routes

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,7 @@ const nextConfig: NextConfig = {
     //
     typedEnv: true,
   },
+  typedRoutes: true,
   
   // from https://env.t3.gg/docs/nextjs :
   // if you turn on `output: "standalone"`, you need to make sure to include `transpilePackages: ["@t3-oss/env-nextjs", "@t3-oss/env-core"]`


### PR DESCRIPTION
### TL;DR

Enable typed routes in Next.js configuration.

### What changed?

Added `typedRoutes: true` to the Next.js configuration file to enable type-safe routing.


### Why make this change?

Enabling typed routes provides better type safety for navigation within the application. This helps catch routing errors at compile time rather than runtime, reducing potential bugs and improving developer experience by providing better autocompletion and validation for route paths.