### PR TITLE
Simplify the format job and leave TODO to improve it later

### DIFF
--- a/.github/build-and-test.yaml
+++ b/.github/build-and-test.yaml
@@ -17,49 +17,68 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref || github.ref_name }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+        # This was important for pushing changes back to the PR branch. Ive disabled this for now.
+        # with:
+        #   ref: ${{ github.head_ref || github.ref_name }}
+        #   token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v4
         with:
           node-version-file: package.json
           cache: "npm"
-      - name: Fetch Prettier Cache
-        uses: actions/cache/restore@v4
-        with:
-          path: ./node_modules/.cache/prettier/.prettier-cache
-          key: prettier-cache-${{ hashFiles('.prettierrc.ts') }} # cache bust on the config file to drop caches if plugins are added
-      - name: Prettier Fix Format
-        id: format
-        run:
-          | # format the codebase with Prettier and take note of the files that were changed
-          {
-            echo 'FORMATTED_FILES<<EOF'
-            npx prettier --write . --cache --list-different
-            echo EOF
-          } >> "$GITHUB_OUTPUT"
-      - name: Save Prettier Cache
-        uses: actions/cache/save@v4
-        with:
-          path: ./node_modules/.cache/prettier/.prettier-cache
-          key: prettier-cache-${{ hashFiles('.prettierrc.ts') }}
-      - name: Commit and Push Prettier Changes
-        run: >
-          if [ -z "${{ steps.format.outputs.FORMATTED_FILES }}" ]; then
-            echo "No files were formatted by Prettier."
-            exit 0
-          fi
-          ; git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          ; git config user.name "github-actions[bot]"
-          ; echo "${{ steps.format.outputs.FORMATTED_FILES }}"
-          | git commit -m "chore: apply Prettier formatting" 
-          --author "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
-          --pathspec-from-file -
-          && git push
+      - name: Run a Prettier Check
+        run: npx prettier --check .
+
+      # TODO: These github cache actions weren't working for some reason. Ill make an issue to fix later. The save action would say "another job may be creating this cache"
+      # - name: Fetch Prettier Cache
+      #   uses: actions/cache/restore@v4
+      #   with:
+      #     path: ./node_modules/.cache/prettier/.prettier-cache
+      #     key: prettier-cache-${{ hashFiles('.prettierrc.ts') }} # cache bust on the config file to drop caches if plugins are added
+      # - name: Prettier Fix Format
+      #   id: format
+      #   run:
+      #     | # format the codebase with Prettier and take note of the files that were changed
+      #     {
+      #       echo 'FORMATTED_FILES<<EOF'
+      #       npx prettier --write . --cache --list-different
+      #       echo EOF
+      #     } >> "$GITHUB_OUTPUT"
+      # - name: Save Prettier Cache
+      #   uses: actions/cache/save@v4
+      #   with:
+      #     path: ./node_modules/.cache/prettier/.prettier-cache
+      #     key: prettier-cache-${{ hashFiles('.prettierrc.ts') }}
+
+      # TODO: Retry the prettier autoformatting. Next time I think it'll be better to have it open up a pull request rather than committing directly
+      # - name: Prettier Fix Format
+      #   id: format
+      #   run:
+      #     | # format the codebase with Prettier and take note of the files that were changed
+      #     {
+      #       echo 'FORMATTED_FILES<<EOF'
+      #       npx prettier --write . --list-different
+      #       echo EOF
+      #     } >> "$GITHUB_OUTPUT"
+      # - name: Commit and Push Prettier Changes
+      #   run: >
+      #     if [ -z "${{ steps.format.outputs.FORMATTED_FILES }}" ]; then
+      #       echo "No files were formatted by Prettier."
+      #       exit 0
+      #     fi
+      #     ; git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      #     ; git config user.name "github-actions[bot]"
+      #     ; echo "${{ steps.format.outputs.FORMATTED_FILES }}"
+      #     | git commit -m "chore: apply Prettier formatting" 
+      #     --author "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+      #     --pathspec-from-file -
+      #     && git push
 
   build-and-lint:
     needs: format
     runs-on: ubuntu-latest
+
+    env:
+      DATABASE_URL: "postgresql://NOT_A_REAL_URL"
 
     steps:
       - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "npx @dotenvx/dotenvx run -- next dev --turbopack",
-    "build": "npx @dotenvx/dotenvx run -- next build --turbopack",
-    "start": "npx @dotenvx/dotenvx run -- next start",
+    "build": "next build --turbopack",
+    "start": "next start",
     "format": "prettier --write . --cache",
     "lint": "npx --node-options='--experimental-strip-types' eslint --flag unstable_native_nodejs_ts_config",
     "postinstall": "prisma generate"


### PR DESCRIPTION
### TL;DR

Replace automatic Prettier formatting with a check-only approach in the CI workflow.

### What changed?

- Disabled the automatic Prettier formatting that would commit changes back to PR branches
- Replaced it with a simple `prettier --check` command that will fail the build if formatting is incorrect
- Commented out the code for caching, formatting, and pushing changes for future reference
- Added a `DATABASE_URL` environment variable to the build-and-lint job so that the build can pass